### PR TITLE
Make `{ <a> }*` an alternative syntax for `{ <a> }`

### DIFF
--- a/naive-ebnf.dtx
+++ b/naive-ebnf.dtx
@@ -435,7 +435,7 @@
   \cs_undefine:N\ebnf_curled%
   \cs_new:Npn\ebnf_curled{%
     \regex_replace_all:nnNT
-    { \{\s(([^\s]*(\s[^\}\{]|\s(\}|\{)[^\s])?)*)\s\}(\+)? }%
+    { \{\s(([^\s]*(\s[^\}\{]|\s(\}|\{)[^\s])?)*)\s\}([\+\*])? }%
     {\c{ebnf@repetition}[\5]{\1}} \ebnf_tmp \ebnf_curled}%
   \ebnf_curled%
   \cs_undefine:N\ebnf_brackets%


### PR DESCRIPTION
Make `{ <a> }*` an alternative syntax for `{ <a> }`.

Some authors prefer `{ <a> }*` rather than `{ <a> }`.
This PR accepts an optional star for a zero-or-more rule.

```latex
\begin{ebnf}
  { <a> }*
\end{ebnf}
```